### PR TITLE
chore: mime should as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,11 @@
     "@mest-fe/prettier": "^0.1.0",
     "@types/node": "^20.7.0",
     "astro": "^3.1.4",
-    "mime": "^3.0.0",
     "prettier": "^3.0.3",
     "typescript": "^5.2.2"
+  },
+  "dependencies": {
+    "mime": "^3.0.0"
   },
   "peerDependencies": {
     "astro": "^3.0.0"


### PR DESCRIPTION
Currently `mime` is a dependency in development. But when this package released. It will missing `mime` unless pre install it.

---

This pull request change `mime` as `dependencies`