### PR TITLE
fix: remove leading slash on Windows machines

### DIFF
--- a/src/image.ts
+++ b/src/image.ts
@@ -2,6 +2,7 @@ import type { AstroConfig, APIRoute } from 'astro'
 // @ts-ignore
 import { getConfiguredImageService, imageConfig } from 'astro:assets'
 import fs from 'node:fs/promises'
+import os from 'node:os';
 // @ts-ignore
 import mime from 'mime/lite'
 
@@ -54,7 +55,10 @@ export const GET: APIRoute = async ({ request }: { request: Request }) => {
   }
 
   let inputBuffer = await loadRemoteImage(sourceUrl)
-  const filePath = transform.src.replace(/^\/@fs/, '').replace(/\?(.*)$/, '')
+  const filePath = (os.platform() === 'win32' 
+    ? transform.src.replace(/^\/@fs\//, '') 
+    : transform.src.replace(/^\/@fs/, '')
+  ).replace(/\?(.*)$/, '')
   inputBuffer ??= await fs.readFile(filePath)
 
   if (!inputBuffer) {


### PR DESCRIPTION
This workaround is working correctly on macOS, but I noticed this is not the case for Windows machines. The 404 my colleague is getting is:
<img width="851" alt="Screenshot_2023-09-27_at_15_17_12" src="https://github.com/unix/astro-https-image-endpoint/assets/487182/935ba381-3364-4de1-8572-c48b6ae5e57d">

As you can see the disk (`D:\`) is appended twice. I figured this is due to a leading slash. This PR removes the leading slash on Windows machines so that the images load correctly.